### PR TITLE
Add `kubernetes-cli` Formula with `kubectl` Alias

### DIFF
--- a/Aliases/kubectl
+++ b/Aliases/kubectl
@@ -1,0 +1,1 @@
+../Formula/kubernetes-cli.rb

--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -1,0 +1,16 @@
+class KubernetesCli < Formula
+  desc "Kubernetes command-line interface"
+  homepage "https://kubernetes.io/"
+  on_arm do
+    url "https://dl.k8s.io/release/v1.24.13/bin/darwin/arm64/kubectl"
+    sha256 "a0b30642de4e0c290e08f1895d7a0951a004f23d107bef86a6460c5f5b516585"
+  end
+  on_intel do
+    url "https://dl.k8s.io/release/v1.24.13/bin/darwin/amd64/kubectl"
+    sha256 "eb0dbc5e55c604b42b19d51609cb2e52e6da9bcde879cdb07d20d74da061be08"
+  end
+
+  def install
+    bin.install "kubectl"
+  end
+end


### PR DESCRIPTION
# Problem
I've encountered two different methods for installing `kubectl` at Semgrep so far:
1. Our [technical onboarding](https://www.notion.so/r2cdev/Technical-Onboarding-c95fcac2be874685bfc680e22e4e7376?pvs=4) has a few manual steps for downloading the `kubectl` executable and moving it to `/usr/local/bin`
2. The `semgrep-app` [Brewfile](https://github.com/returntocorp/semgrep-app/blob/fc41a5dc611bd4b98841aac10673b61b92c5b852/Brewfile#L26) has an entry for `kubernetes-cli`

Option 1 isn't ideal because we should strive to use a single package manager for all of our local tools for consistency and reducing cognitive load on developers. Option 2 uses a package manager but gets the wrong version because upstream Homebrew lives on the pretty bleeding edge. Developers will end up with v1.27 currently, which is not compatible with our clusters on 1.23 (`kubectl` supports +/- 1 version). It's also not great that we have two different methods for installing `kubectl` because that makes it difficult for infra engineers who need to use option 1 to also use the nice Makefile tooling in `semgrep-app` since they'll conflict.

# Solution
I've created a private Homebrew Tap, which you can install locally via `brew tap returntocorp/infra`, and added a `kubernetes-cli` Formula with a `kubectl` alias (this is how things are named upstream). It installs v1.24.13, which is the latest available version that is still compatible with our clusters.

I opted to keep the Formula named simply `kubernetes-cli` as opposed to the common Homebrew versioning pattern of `kubernetes-cli@1.24` because the latter is more annoying to upgrade. When we do support a new version, users will simply be able to `brew upgrade` instead of `brew uninstall kubernetes-cli@1.24 && brew install kubernetes-cli@1.25`.