### PR TITLE
Add `libxmlsec1@1.2.37` Formula

### DIFF
--- a/Formula/libxmlsec1@1.2.37.rb
+++ b/Formula/libxmlsec1@1.2.37.rb
@@ -1,0 +1,68 @@
+# Generated via `brew extract --version=1.2.37 libxmlsec1 returntocorp/infra`
+# Workaround for this bug: https://github.com/xmlsec/python-xmlsec/issues/254
+class Libxmlsec1AT1237 < Formula
+  desc "XML security library"
+  homepage "https://www.aleksey.com/xmlsec/"
+  url "https://www.aleksey.com/xmlsec/download/xmlsec1-1.2.37.tar.gz"
+  sha256 "5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c"
+  license "MIT"
+
+  livecheck do
+    url "https://www.aleksey.com/xmlsec/download/"
+    regex(/href=.*?xmlsec1[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "gnutls" # Yes, it wants both ssl/tls variations
+  depends_on "libgcrypt"
+  depends_on "libxml2"
+  depends_on "openssl@1.1"
+  uses_from_macos "libxslt"
+
+  on_macos do
+    depends_on xcode: :build
+  end
+
+  # Add HOMEBREW_PREFIX/lib to dl load path
+  patch :DATA
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
+  def install
+    args = ["--disable-dependency-tracking",
+            "--prefix=#{prefix}",
+            "--disable-crypto-dl",
+            "--disable-apps-crypto-dl",
+            "--with-nss=no",
+            "--with-nspr=no",
+            "--enable-mscrypto=no",
+            "--enable-mscng=no",
+            "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"]
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/xmlsec1", "--version"
+    system "#{bin}/xmlsec1-config", "--version"
+  end
+end
+
+__END__
+diff --git a/src/dl.c b/src/dl.c
+index 6e8a56a..0e7f06b 100644
+--- a/src/dl.c
++++ b/src/dl.c
+@@ -141,6 +141,7 @@ xmlSecCryptoDLLibraryCreate(const xmlChar* name) {
+     }
+
+ #ifdef XMLSEC_DL_LIBLTDL
++    lt_dlsetsearchpath("HOMEBREW_PREFIX/lib");
+     lib->handle = lt_dlopenext((char*)lib->filename);
+     if(lib->handle == NULL) {
+         xmlSecError(XMLSEC_ERRORS_HERE,


### PR DESCRIPTION
# Problem
As of 4/12/23, `xmlsec` [v1.3.0](https://github.com/lsh123/xmlsec/releases/tag/xmlsec_1_3_0) was released, which appears to be incompatible with the latest version of `python-xmlsec` (see [this issue for details](https://github.com/xmlsec/python-xmlsec/issues/254)). Homebrew core also rolled out that version, so any developers that install or update that Formula cannot install `python-xmlsec`.

# Solution
[This workaround](https://github.com/xmlsec/python-xmlsec/issues/254#issuecomment-1511135314) describes how to create a copy of the last working version of the Formula. Rather than asking all developers to take those manual steps, however, we can add the Formula to our internal tap.