### PR TITLE
Set version explicitly for `kustomize` Formula

### DIFF
--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -1,6 +1,7 @@
 class Kustomize < Formula
   desc "Template-free customization of Kubernetes YAML manifests"
   homepage "https://github.com/kubernetes-sigs/kustomize"
+  version "4.2.0"
   on_arm do
     url "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.2.0/kustomize_v4.2.0_darwin_arm64.tar.gz"
     sha256 "7ad70475fe5684f7150f7f1825df5f17652ec812fa65129b756000e9a6b49fff"


### PR DESCRIPTION
Homebrew attempts to infer the version from the given `url`, but for some reason it fails to do so correctly for this Formula (it thinks the version should be 64). This explicitly sets the `version` field instead.