### PR TITLE
fix(libxmlsec1): update URL

### DIFF
--- a/Formula/libxmlsec1@1.2.37.rb
+++ b/Formula/libxmlsec1@1.2.37.rb
@@ -3,7 +3,7 @@
 class Libxmlsec1AT1237 < Formula
   desc "XML security library"
   homepage "https://www.aleksey.com/xmlsec/"
-  url "https://www.aleksey.com/xmlsec/download/xmlsec1-1.2.37.tar.gz"
+  url "https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-1.2.37.tar.gz"
   sha256 "5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c"
   license "MIT"
 


### PR DESCRIPTION
# Problem
The shorter download URL now points to v1.2.38, so the existing URL in this formula returns a 404.

# Solution
Use the `older-releases` URL that contains all versions and won't break.