### PR TITLE
Add `aws-vpn-client-semgrep` Cask at v3.6.0

### DIFF
--- a/Casks/aws-vpn-client-semgrep.rb
+++ b/Casks/aws-vpn-client-semgrep.rb
@@ -1,0 +1,36 @@
+cask "aws-vpn-client-semgrep" do
+  version "3.6.0"
+  sha256 "40eb2978931a7e5af4a64d8c2ba39913c38ad36092a47ec81943eebc4d0901fc"
+
+  url "https://d20adtppz83p9s.cloudfront.net/OSX/#{version}/AWS_VPN_Client.pkg",
+      verified: "d20adtppz83p9s.cloudfront.net/"
+  name "AWS Client VPN"
+  desc "Managed client-based VPN service to securely access AWS resources"
+  homepage "https://aws.amazon.com/vpn/"
+
+  livecheck do
+    url "https://docs.aws.amazon.com/vpn/latest/clientvpn-user/client-vpn-connect-macos.html"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/AWS_VPN_Client\.pkg}i)
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  conflicts_with cask: "aws-vpn-client"
+
+  pkg "AWS_VPN_Client.pkg"
+
+  uninstall pkgutil:   "com.amazon.awsvpnclient",
+            quit:      "com.amazonaws.acvc.osx",
+            launchctl: "com.amazonaws.acvc.helper",
+            delete:    [
+              "/Library/Application Support/AWSVPNClient",
+              "/Library/LaunchDaemons/com.amazonaws.acvc.helper.plist",
+              "/Library/PrivilegedHelperTools/com.amazonaws.acvc.helper",
+            ]
+
+  zap trash: [
+    "~/.config/AWSVPNClient",
+    "~/Library/Preferences/com.amazonaws.acvc.osx.plist",
+    "~/Library/Saved Application State/com.amazonaws.acvc.osx.savedState",
+  ]
+end


### PR DESCRIPTION
# Problem
Version 3.7.0 of `aws-vpn-client` contains a bug that prevents using the internet while on the VPN.

# Solution
Add version 3.6.0 of the Homebrew Cask that provides this application to our infra Homebrew tap. A few notes:
1. It is named `aws-vpn-client-semgrep` so that once it's installed, a user can't accidentally run `brew upgrade` and have it upgraded to the upstream version of `aws-vpn-client`. Casks don't support versioning like `aws-vpn-client@3.6.0` like Formulae do, unfortunately, so it needs to have a different name.
2. It "conflicts" with `aws-vpn-client` so that you can't accidentally install it while the original is installed because one will partially overwrite the other and leave you in a weird state. Unfortunately, we can't update the upstream `aws-vpn-client` Cask to conflict with our Cask, so you _can_ still accidentally install `aws-vpn-client` if you already have `aws-vpn-client-semgrep` installed. I will update any docs as well as the `Brewfile.infra` in `semgrep-app` to prevent this from happening that way, and users shouldn't have a reason to install the original otherwise.