### PR TITLE
Pin libxml2 to 2.11.5 for compatibility with pinned libxmlsec1

### DIFF
--- a/Formula/libxml2@2.11.5.rb
+++ b/Formula/libxml2@2.11.5.rb
@@ -1,0 +1,107 @@
+class Libxml2AT2115 < Formula
+    desc "GNOME XML library"
+    homepage "http://xmlsoft.org/"
+    url "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.5.tar.xz"
+    sha256 "3727b078c360ec69fa869de14bd6f75d7ee8d36987b071e6928d4720a28df3a6"
+    license "MIT"
+    revision 1
+
+    # We use a common regex because libxml2 doesn't use GNOME's "even-numbered
+    # minor is stable" version scheme.
+    livecheck do
+      url :stable
+      regex(/libxml2[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    end
+
+    head do
+      url "https://gitlab.gnome.org/GNOME/libxml2.git", branch: "master"
+
+      depends_on "autoconf" => :build
+      depends_on "automake" => :build
+      depends_on "libtool" => :build
+      depends_on "pkg-config" => :build
+    end
+
+    keg_only :provided_by_macos
+
+    depends_on "python-setuptools" => :build
+    depends_on "python@3.10" => [:build, :test]
+    depends_on "python@3.11" => [:build, :test]
+    depends_on "python@3.12" => [:build, :test]
+    depends_on "pkg-config" => :test
+    depends_on "icu4c"
+    depends_on "readline"
+
+    uses_from_macos "zlib"
+
+    def pythons
+      deps.map(&:to_formula)
+          .select { |f| f.name.match?(/^python@\d\.\d+$/) }
+          .map { |f| f.opt_libexec/"bin/python" }
+    end
+
+    def install
+      system "autoreconf", "--force", "--install", "--verbose" if build.head?
+      system "./configure", *std_configure_args,
+                            "--sysconfdir=#{etc}",
+                            "--disable-silent-rules",
+                            "--with-history",
+                            "--with-icu",
+                            "--without-python",
+                            "--without-lzma"
+      system "make", "install"
+
+      cd "python" do
+        sdk_include = if OS.mac?
+          sdk = MacOS.sdk_path_if_needed
+          sdk/"usr/include" if sdk
+        else
+          HOMEBREW_PREFIX/"include"
+        end
+
+        includes = [include, sdk_include].compact.map do |inc|
+          "'#{inc}',"
+        end.join(" ")
+
+        # We need to insert our include dir first
+        inreplace "setup.py", "includes_dir = [",
+                              "includes_dir = [#{includes}"
+
+        pythons.each do |python|
+          system python, "-m", "pip", "install", *std_pip_args, "."
+        end
+      end
+    end
+
+    test do
+      (testpath/"test.c").write <<~EOS
+        #include <libxml/tree.h>
+
+        int main()
+        {
+          xmlDocPtr doc = xmlNewDoc(BAD_CAST "1.0");
+          xmlNodePtr root_node = xmlNewNode(NULL, BAD_CAST "root");
+          xmlDocSetRootElement(doc, root_node);
+          xmlFreeDoc(doc);
+          return 0;
+        }
+      EOS
+
+      # Test build with xml2-config
+      args = shell_output("#{bin}/xml2-config --cflags --libs").split
+      system ENV.cc, "test.c", "-o", "test", *args
+      system "./test"
+
+      # Test build with pkg-config
+      ENV.append "PKG_CONFIG_PATH", lib/"pkgconfig"
+      args = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libxml-2.0").split
+      system ENV.cc, "test.c", "-o", "test", *args
+      system "./test"
+
+      pythons.each do |python|
+        with_env(PYTHONPATH: prefix/Language::Python.site_packages(python)) do
+          system python, "-c", "import libxml2"
+        end
+      end
+    end
+  end

--- a/Formula/libxmlsec1@1.2.37.rb
+++ b/Formula/libxmlsec1@1.2.37.rb
@@ -15,7 +15,7 @@ class Libxmlsec1AT1237 < Formula
   depends_on "pkg-config" => :build
   depends_on "gnutls" # Yes, it wants both ssl/tls variations
   depends_on "libgcrypt"
-  depends_on "libxml2"
+  depends_on "libxml2@2.11.5"
   depends_on "openssl@1.1"
   uses_from_macos "libxslt"
 


### PR DESCRIPTION
# Problem
Installing `libxmlsec1@1.2.37` (a transitive dependency of `semgrep-app`) started failing with this error:
```
make[2]: *** [keyinfo.lo] Error 1
make[2]: *** [c14n.lo] Error 1
buffer.c:638:12: error: call to undeclared function 'xmlOutputBufferCreateIO'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    return(xmlOutputBufferCreateIO((xmlOutputWriteCallback)xmlSecBufferIOWrite,
           ^
buffer.c:638:37: error: use of undeclared identifier 'xmlOutputWriteCallback'
    return(xmlOutputBufferCreateIO((xmlOutputWriteCallback)xmlSecBufferIOWrite,
                                    ^
buffer.c:639:39: error: use of undeclared identifier 'xmlOutputCloseCallback'
                                     (xmlOutputCloseCallback)xmlSecBufferIOClose,
                                      ^
4 errors generated.
make[2]: *** [buffer.lo] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [install-recursive] Error 1
```

Upstream homebrew recently released `libxml2` v2.12, which seems like it might have some breaking changes. Their [changelog](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.0) references the use of a `--with-legacy` config flag for retaining ABI compatibility, which suggests that they might have removed some deprecated symbols.

# Solution
1. Create a `libxml2@2.11.5` Formula using the [upstream Formula from that point](https://github.com/Homebrew/homebrew-core/blob/38ba35404e3cdb398694419850179e0023158887/Formula/lib/libxml2.rb), but with the bottle definitions removed since those no longer exist.
2. Update the `libxmlsec1@1.2.37` Formula to point to `libxml2@2.11.5` instead of `libxml2`.

# Future Work
This is going to be a never-ending battle as Homebrew marches on and the Python `xmlsec` package continues to be unmaintained. We have a few options:
1. Attempt to contribute a fix to the Python `xmlsec` package ourselves
2. Try to find another SAML library to get this dependency out of our tree?
3. Switch to something like dev containers for local dev and stop relying on Homebrew entirely